### PR TITLE
Follow up on changes to internal cards, stats

### DIFF
--- a/app/controllers/internalRequestController.js
+++ b/app/controllers/internalRequestController.js
@@ -28,9 +28,9 @@ app.controller('InternalRequestController', function ($controller, $scope, ApiRe
     $scope.resetInternalRequestForms();
 
     $scope.selectRemoteProducts = function () {
-      if ($scope.featureRequestToPush.productId) {
-        if (!$scope.remoteProducts[$scope.featureRequestToPush.productId]) {
-          $scope.refreshRemoteProducts($scope.featureRequestToPush.productId);
+      if ($scope.featureRequestToPush.product && $scope.featureRequestToPush.product.id) {
+        if (!$scope.remoteProducts[$scope.featureRequestToPush.product.id]) {
+          $scope.refreshRemoteProducts($scope.featureRequestToPush.product.id);
         }
       }
     };
@@ -41,8 +41,20 @@ app.controller('InternalRequestController', function ($controller, $scope, ApiRe
       }
     };
 
+    $scope.addInternalRequest = function () {
+      if (!$scope.productsLoading) {
+        ProductsService.refreshProducts();
+      }
+
+      $scope.openModal('#addInternalRequestModal');
+    };
+
     $scope.createInternalRequest = function () {
       $scope.internalRequestToCreate.createdOn = new Date().getTime();
+
+      if (!$scope.productsLoading) {
+        ProductsService.refreshProducts();
+      }
 
       InternalRequestRepo.create($scope.internalRequestToCreate).then(function (res) {
         if (angular.fromJson(res.body).meta.status === 'SUCCESS') {
@@ -62,7 +74,7 @@ app.controller('InternalRequestController', function ($controller, $scope, ApiRe
         title: internalRequest.title,
         description: internalRequest.description,
         rpmId: null,
-        productId: null,
+        product: internalRequest.product,
         scopeId: null
       };
 
@@ -75,7 +87,7 @@ app.controller('InternalRequestController', function ($controller, $scope, ApiRe
 
     $scope.pushFeatureRequest = function () {
       for (var key in $scope.products) {
-        if ($scope.products[key].id == $scope.featureRequestToPush.productId) {
+        if ($scope.products[key].id == $scope.featureRequestToPush.product.id) {
           for (var k in $scope.products[key].remoteProductInfo) {
             if ($scope.products[key].remoteProductInfo[k].scopeId == $scope.featureRequestToPush.scopeId) {
               $scope.featureRequestToPush.rpmId = $scope.products[key].remoteProductInfo[k].remoteProductManager.id;
@@ -101,6 +113,11 @@ app.controller('InternalRequestController', function ($controller, $scope, ApiRe
 
     $scope.editInternalRequest = function (internalRequest) {
       $scope.internalRequestToEdit = angular.copy(internalRequest);
+
+      if (!$scope.productsLoading) {
+        ProductsService.refreshProducts();
+      }
+
       $scope.openModal('#editInternalRequestModal');
     };
 

--- a/app/repo/internalRequestRepo.js
+++ b/app/repo/internalRequestRepo.js
@@ -4,6 +4,7 @@ app.repo("InternalRequestRepo", function InternalRequestRepo() {
   internalRequestRepo.scaffold = {
     title: '',
     description: '',
+    product: null,
     createdOn: null
   };
 

--- a/app/services/internalRequestsService.js
+++ b/app/services/internalRequestsService.js
@@ -6,7 +6,7 @@ app.service('InternalRequestsService', function ($q, WsApi) {
       data: featureRequest.scopeId,
       pathValues: {
         requestId: featureRequest.id,
-        productId: featureRequest.productId,
+        productId: featureRequest.product ? featureRequest.product.id : null,
         rpmId: featureRequest.rpmId,
       }
     };

--- a/app/views/home.html
+++ b/app/views/home.html
@@ -99,6 +99,7 @@
               <th>Defect Count</th>
               <th>Request Count</th>
               <th>Issue Count</th>
+              <th>Internal Count</th>
             </tr>
             <tr ng-repeat="product in products | orderBy: '-stats.backlogItemCount'">
               <td title="'Product'">{{product.name}}</td>
@@ -107,6 +108,7 @@
               <td title="'Defect Count'">{{product.stats.defectCount}}</td>
               <td title="'Request Count'">{{product.stats.requestCount}}</td>
               <td title="'Issue Count'">{{product.stats.issueCount}}</td>
+              <td title="'Internal Count'">{{product.stats.internalCount}}</td>
             </tr>
           </table>
 
@@ -118,10 +120,14 @@
 
           <table class="table table-bordered table-striped product-table">
             <tr>
-              <th>Internal Requests</th>
+              <th>Associated with a Product</th>
+              <th>Not Associated with a Product</th>
+              <th>Total Internal Requests</th>
             </tr>
             <tr>
-              <td title="'Count'">{{stats.internalCount}}</td>
+              <td title="'Count'">{{stats.assignedCount}}</td>
+              <td title="'Count'">{{stats.unassignedCount}}</td>
+              <td title="'Count'">{{stats.totalCount}}</td>
             </tr>
           </table>
 

--- a/app/views/management/internalRequests.html
+++ b/app/views/management/internalRequests.html
@@ -1,6 +1,6 @@
 <div class="management-table" ng-controller="InternalRequestController">
 
-  <button class="btn btn-default view-action-button" ng-click="openModal('#addInternalRequestModal')">Add an Internal Request</button>
+  <button class="btn btn-default view-action-button" ng-click="addInternalRequest()">Add an Internal Request</button>
   <hr>
 
   <table class="table table-bordered table-striped internalRequest-table">

--- a/app/views/modals/addInternalRequestModal.html
+++ b/app/views/modals/addInternalRequestModal.html
@@ -34,6 +34,13 @@
       results="internalRequestForms.getResults()"
       autocomplete="off">
     </validatedtextarea>
+
+    <div class="form-group">
+      <label for="product">Associate Product</label>
+      <select name="product" class="form-control" ng-model="internalRequestToCreate.product" ng-options="product as product.name for product in products track by product.id" ng-change="selectRemoteProducts()" ng-disabled="productsLoading">
+        <option value="" selected>None</option>
+      </select>
+    </div>
   </div>
 
   <div class="modal-footer">

--- a/app/views/modals/editInternalRequestModal.html
+++ b/app/views/modals/editInternalRequestModal.html
@@ -34,6 +34,13 @@
       results="internalRequestForms.getResults()"
       autocomplete="off">
     </validatedtextarea>
+
+    <div ng-if="products" class="form-group">
+      <label for="product">Associate Product</label>
+      <select name="product" class="form-control" ng-model="internalRequestToEdit.product" ng-options="product as product.name for product in products track by product.id" ng-change="selectRemoteProducts()" ng-disabled="productsLoading">
+        <option value="" selected>None</option>
+      </select>
+    </div>
   </div>
 
   <div class="modal-footer">

--- a/app/views/modals/pushInternalRequestModal.html
+++ b/app/views/modals/pushInternalRequestModal.html
@@ -5,7 +5,7 @@
   <h4 class="modal-title">Push Internal Request (Feature Request)</h4>
 </div>
 
-<form name="internalRequestForms.push" ng-submit="pushFeatureRequest()" novalidate>
+<form ng-if="featureRequestToPush.id" name="internalRequestForms.push" ng-submit="pushFeatureRequest()" novalidate>
 
   <validationmessage results="internalRequestForms.getResults()"></validationmessage>
 
@@ -36,16 +36,16 @@
       autocomplete="off">
     </validatedinput>
 
-    <div class="form-group">
-      <label for="productId">Associate Product</label>
-      <select name="productId" class="form-control" ng-model="featureRequestToPush.productId" ng-options="product.id as product.name for product in products | orderBy:'name'" ng-change="selectRemoteProducts()" ng-disabled="productsLoading">
+    <div ng-if="products" class="form-group">
+      <label for="product">Associate Product</label>
+      <select name="product" class="form-control" ng-model="featureRequestToPush.product" ng-options="product as product.name for product in products track by product.id" ng-change="selectRemoteProducts()" disabled="disabled">
         <option value="" selected>None</option>
       </select>
     </div>
 
-    <div class="form-group" ng-if="featureRequestToPush.productId">
+    <div class="form-group" ng-if="featureRequestToPush.product.id">
       <label for="scopeId">Associate Remote Product</label>
-      <select name="scopeId" class="form-control" ng-model="featureRequestToPush.scopeId" ng-options="remoteProduct.id as remoteProduct.name for remoteProduct in remoteProducts[featureRequestToPush.productId]" ng-disabled="productsLoading || remoteProductsLoading[featureRequestToPush.productId]">
+      <select name="scopeId" class="form-control" ng-model="featureRequestToPush.scopeId" ng-options="remoteProduct.id as remoteProduct.name for remoteProduct in remoteProducts[featureRequestToPush.product.id]" ng-disabled="productsLoading || remoteProductsLoading[featureRequestToPush.product.id]">
         <option value="" selected>None</option>
       </select>
     </div>

--- a/tests/e2e/index-spec.js
+++ b/tests/e2e/index-spec.js
@@ -2,15 +2,15 @@ describe("index", function () {
 
   it("is navigatable", function () {
     browser.get("");
-  })
+  });
 
   it("body is displayed", function () {
     expect($("body").isDisplayed()).toBeTruthy();
-  })
+  });
 
   it("has tamuheader", function () {
     expect($("tamuheader").isDisplayed()).toBeTruthy();
-  })
+  });
 
   it("has tamufooter", function () {
     expect($("tamufooter").isDisplayed()).toBeTruthy();

--- a/tests/e2e/users-spec.js
+++ b/tests/e2e/users-spec.js
@@ -24,11 +24,11 @@ describe("users", function () {
     browser.wait(EC.visibilityOf($("username")), 5000);
 
     expect($("username").getText()).toEqual("Library Test4");
-  })
+  });
 
   it("synchronize", function () {
     browser.ignoreSynchronization = false;
-  })
+  });
 
   it("has access to manage users", function () {
 
@@ -43,7 +43,7 @@ describe("users", function () {
       expect(cells.count()).toEqual(6);
     });
 
-  })
+  });
 
   it("can change user role to manager", function () {
 
@@ -68,7 +68,7 @@ describe("users", function () {
       });
     });
 
-  })
+  });
 
   it("can change user role back to user", function () {
 

--- a/tests/mock/model/mockInternalRequest.js
+++ b/tests/mock/model/mockInternalRequest.js
@@ -2,6 +2,7 @@ var dataInternalRequest1 = {
   id: 1,
   createdOn: 1588262229449,
   description: "description 1",
+  product: null,
   title: "Internal Request 1"
 };
 
@@ -9,6 +10,7 @@ var dataInternalRequest2 = {
   id: 2,
   createdOn: 1588262283332,
   description: "description 2",
+  product: null,
   title: "Internal Request 2"
 };
 
@@ -16,6 +18,7 @@ var dataInternalRequest3 = {
   id: 3,
   createdOn: 1588262294703,
   description: "description 3",
+  product: null,
   title: "Internal Request 3"
 
 };

--- a/tests/mock/repo/mockInternalRequestRepo.js
+++ b/tests/mock/repo/mockInternalRequestRepo.js
@@ -22,6 +22,7 @@ angular.module("mock.internalRequestRepo", []).service("InternalRequestRepo", fu
   repo.scaffold = {
     title: '',
     description: '',
+    product: null,
     createdOn: null
   };
 

--- a/tests/mock/service/mockProductStatsService.js
+++ b/tests/mock/service/mockProductStatsService.js
@@ -5,6 +5,7 @@ var dataProductsStats = [{
   issueCount: 41,
   featureCount: 32,
   defectCount: 0,
+  internalCount: 0,
   backlogItemCount: 32
 }, {
   id: 2,
@@ -13,6 +14,7 @@ var dataProductsStats = [{
   issueCount: 0,
   featureCount: 5,
   defectCount: 0,
+  internalCount: 0,
   backlogItemCount: 5
 }, {
   id: 3,
@@ -21,6 +23,7 @@ var dataProductsStats = [{
   issueCount: 0,
   featureCount: 12,
   defectCount: 8,
+  internalCount: 0,
   backlogItemCount: 20
 }, {
   id: 4,
@@ -29,6 +32,7 @@ var dataProductsStats = [{
   issueCount: 0,
   featureCount: 42,
   defectCount: 0,
+  internalCount: 0,
   backlogItemCount: 42
 }, {
   id: 5,
@@ -37,6 +41,7 @@ var dataProductsStats = [{
   issueCount: 0,
   featureCount: 6,
   defectCount: 0,
+  internalCount: 0,
   backlogItemCount: 6
 }, {
   id: 6,
@@ -45,6 +50,7 @@ var dataProductsStats = [{
   issueCount: 0,
   featureCount: 43,
   defectCount: 0,
+  internalCount: 0,
   backlogItemCount: 43
 }, {
   id: 7,
@@ -53,6 +59,7 @@ var dataProductsStats = [{
   issueCount: 0,
   featureCount: 4,
   defectCount: 0,
+  internalCount: 0,
   backlogItemCount: 4
 }, {
   id: 8,
@@ -61,6 +68,7 @@ var dataProductsStats = [{
   issueCount: 0,
   featureCount: 10,
   defectCount: 0,
+  internalCount: 0,
   backlogItemCount: 10
 }, {
   id: 9,
@@ -69,6 +77,7 @@ var dataProductsStats = [{
   issueCount: 0,
   featureCount: 3,
   defectCount: 0,
+  internalCount: 0,
   backlogItemCount: 3
 }, {
   id: 10,
@@ -77,6 +86,7 @@ var dataProductsStats = [{
   issueCount: 0,
   featureCount: 0,
   defectCount: 0,
+  internalCount: 0,
   backlogItemCount: 0
 }, {
   id: 11,
@@ -85,6 +95,7 @@ var dataProductsStats = [{
   issueCount: 0,
   featureCount: 38,
   defectCount: 0,
+  internalCount: 0,
   backlogItemCount: 38
 }, {
   id: 12,
@@ -93,6 +104,7 @@ var dataProductsStats = [{
   issueCount: 0,
   featureCount: 10,
   defectCount: 0,
+  internalCount: 0,
   backlogItemCount: 10
 }, {
   id: 13,
@@ -101,6 +113,7 @@ var dataProductsStats = [{
   issueCount: 0,
   featureCount: 9,
   defectCount: 0,
+  internalCount: 0,
   backlogItemCount: 9
 }, {
   id: 14,
@@ -109,6 +122,7 @@ var dataProductsStats = [{
   issueCount: 1,
   featureCount: 5,
   defectCount: 0,
+  internalCount: 0,
   backlogItemCount: 5
 }, {
   id: 15,
@@ -117,6 +131,7 @@ var dataProductsStats = [{
   issueCount: 0,
   featureCount: 13,
   defectCount: 0,
+  internalCount: 0,
   backlogItemCount: 13
 }, {
   id: 16,
@@ -125,6 +140,7 @@ var dataProductsStats = [{
   issueCount: 4,
   featureCount: 25,
   defectCount: 6,
+  internalCount: 0,
   backlogItemCount: 31
 }, {
   id: 17,
@@ -133,6 +149,7 @@ var dataProductsStats = [{
   issueCount: 1,
   featureCount: 16,
   defectCount: 3,
+  internalCount: 0,
   backlogItemCount: 19
 }, {
   id: 18,
@@ -141,6 +158,7 @@ var dataProductsStats = [{
   issueCount: 0,
   featureCount: 18,
   defectCount: 0,
+  internalCount: 0,
   backlogItemCount: 18
 }, {
   id: 19,
@@ -149,6 +167,7 @@ var dataProductsStats = [{
   issueCount: 0,
   featureCount: 0,
   defectCount: 0,
+  internalCount: 0,
   backlogItemCount: 0
 }, {
   id: 20,
@@ -157,6 +176,7 @@ var dataProductsStats = [{
   issueCount: 9,
   featureCount: 24,
   defectCount: 1,
+  internalCount: 0,
   backlogItemCount: 25
 }, {
   id: 21,
@@ -165,6 +185,7 @@ var dataProductsStats = [{
   issueCount: 11,
   featureCount: 6,
   defectCount: 2,
+  internalCount: 0,
   backlogItemCount: 8
 }, {
   id: 22,
@@ -173,6 +194,7 @@ var dataProductsStats = [{
   issueCount: 2,
   featureCount: 8,
   defectCount: 0,
+  internalCount: 0,
   backlogItemCount: 8
 }, {
   id: 23,
@@ -181,6 +203,7 @@ var dataProductsStats = [{
   issueCount: 0,
   featureCount: 0,
   defectCount: 0,
+  internalCount: 0,
   backlogItemCount: 0
 }, {
   id: 24,
@@ -189,6 +212,7 @@ var dataProductsStats = [{
   issueCount: 0,
   featureCount: 0,
   defectCount: 0,
+  internalCount: 0,
   backlogItemCount: 0
 }, {
   id: 25,
@@ -197,6 +221,7 @@ var dataProductsStats = [{
   issueCount: 2,
   featureCount: 4,
   defectCount: 1,
+  internalCount: 0,
   backlogItemCount: 5
 }, {
   id: 26,
@@ -205,6 +230,7 @@ var dataProductsStats = [{
   issueCount: 0,
   featureCount: 2,
   defectCount: 1,
+  internalCount: 0,
   backlogItemCount: 3
 }, {
   id: 27,
@@ -213,6 +239,7 @@ var dataProductsStats = [{
   issueCount: 0,
   featureCount: 8,
   defectCount: 0,
+  internalCount: 0,
   backlogItemCount: 8
 }, {
   id: 28,
@@ -221,6 +248,7 @@ var dataProductsStats = [{
   issueCount: 0,
   featureCount: 8,
   defectCount: 0,
+  internalCount: 0,
   backlogItemCount: 8
 }, {
   id: 29,
@@ -229,6 +257,7 @@ var dataProductsStats = [{
   issueCount: 0,
   featureCount: 0,
   defectCount: 0,
+  internalCount: 0,
   backlogItemCount: 0
 }, {
   id: 30,
@@ -237,6 +266,7 @@ var dataProductsStats = [{
   issueCount: 1,
   featureCount: 24,
   defectCount: 0,
+  internalCount: 0,
   backlogItemCount: 24
 }, {
   id: 31,
@@ -245,6 +275,7 @@ var dataProductsStats = [{
   issueCount: 2,
   featureCount: 2,
   defectCount: 0,
+  internalCount: 0,
   backlogItemCount: 2
 }, {
   id: 32,
@@ -253,6 +284,7 @@ var dataProductsStats = [{
   issueCount: 0,
   featureCount: 9,
   defectCount: 0,
+  internalCount: 0,
   backlogItemCount: 9
 }, {
   id: 33,
@@ -261,6 +293,7 @@ var dataProductsStats = [{
   issueCount: 0,
   featureCount: 10,
   defectCount: 0,
+  internalCount: 0,
   backlogItemCount: 10
 }, {
   id: 34,
@@ -269,6 +302,7 @@ var dataProductsStats = [{
   issueCount: 0,
   featureCount: 18,
   defectCount: 5,
+  internalCount: 0,
   backlogItemCount: 23
 }, {
   id: 35,
@@ -277,6 +311,7 @@ var dataProductsStats = [{
   issueCount: 0,
   featureCount: 0,
   defectCount: 0,
+  internalCount: 0,
   backlogItemCount: 0
 }, {
   id: 36,
@@ -285,6 +320,7 @@ var dataProductsStats = [{
   issueCount: 0,
   featureCount: 0,
   defectCount: 0,
+  internalCount: 0,
   backlogItemCount: 0
 }, {
   id: 37,
@@ -293,6 +329,7 @@ var dataProductsStats = [{
   issueCount: 0,
   featureCount: 0,
   defectCount: 0,
+  internalCount: 0,
   backlogItemCount: 0
 }, {
   id: 38,
@@ -301,6 +338,7 @@ var dataProductsStats = [{
   issueCount: 0,
   featureCount: 5,
   defectCount: 1,
+  internalCount: 0,
   backlogItemCount: 6
 }, {
   id: 39,
@@ -309,6 +347,7 @@ var dataProductsStats = [{
   issueCount: 0,
   featureCount: 0,
   defectCount: 0,
+  internalCount: 0,
   backlogItemCount: 0
 }, {
   id: 40,
@@ -317,6 +356,7 @@ var dataProductsStats = [{
   issueCount: 0,
   featureCount: 3,
   defectCount: 0,
+  internalCount: 0,
   backlogItemCount: 3
 }, {
   id: 41,
@@ -325,6 +365,7 @@ var dataProductsStats = [{
   issueCount: 0,
   featureCount: 3,
   defectCount: 0,
+  internalCount: 0,
   backlogItemCount: 3
 }, {
   id: 42,
@@ -333,6 +374,7 @@ var dataProductsStats = [{
   issueCount: 0,
   featureCount: 1,
   defectCount: 0,
+  internalCount: 0,
   backlogItemCount: 1
 }, {
   id: 43,
@@ -341,6 +383,7 @@ var dataProductsStats = [{
   issueCount: 0,
   featureCount: 1,
   defectCount: 2,
+  internalCount: 0,
   backlogItemCount: 3
 }, {
   id: 44,
@@ -349,6 +392,7 @@ var dataProductsStats = [{
   issueCount: 0,
   featureCount: 4,
   defectCount: 0,
+  internalCount: 0,
   backlogItemCount: 4
 }, {
   id: 45,
@@ -357,6 +401,7 @@ var dataProductsStats = [{
   issueCount: 0,
   featureCount: 1,
   defectCount: 0,
+  internalCount: 0,
   backlogItemCount: 1
 }, {
   id: 46,
@@ -365,6 +410,7 @@ var dataProductsStats = [{
   issueCount: 0,
   featureCount: 5,
   defectCount: 5,
+  internalCount: 0,
   backlogItemCount: 10
 }, {
   id: 47,
@@ -373,6 +419,7 @@ var dataProductsStats = [{
   issueCount: 2,
   featureCount: 5,
   defectCount: 1,
+  internalCount: 0,
   backlogItemCount: 6
 }, {
   id: 48,
@@ -381,6 +428,7 @@ var dataProductsStats = [{
   issueCount: 0,
   featureCount: 4,
   defectCount: 1,
+  internalCount: 0,
   backlogItemCount: 5
 }, {
   id: 49,
@@ -389,6 +437,7 @@ var dataProductsStats = [{
   issueCount: 0,
   featureCount: 18,
   defectCount: 1,
+  internalCount: 0,
   backlogItemCount: 19
 }, {
   id: 50,
@@ -397,6 +446,7 @@ var dataProductsStats = [{
   issueCount: 0,
   featureCount: 34,
   defectCount: 4,
+  internalCount: 0,
   backlogItemCount: 38
 }, {
   id: 51,
@@ -405,6 +455,7 @@ var dataProductsStats = [{
   issueCount: 0,
   featureCount: 0,
   defectCount: 0,
+  internalCount: 0,
   backlogItemCount: 0
 }, {
   id: 52,
@@ -413,6 +464,7 @@ var dataProductsStats = [{
   issueCount: 0,
   featureCount: 19,
   defectCount: 2,
+  internalCount: 0,
   backlogItemCount: 21
 }, {
   id: 53,
@@ -421,6 +473,7 @@ var dataProductsStats = [{
   issueCount: 0,
   featureCount: 2,
   defectCount: 1,
+  internalCount: 0,
   backlogItemCount: 3
 }, {
   id: 54,
@@ -429,6 +482,7 @@ var dataProductsStats = [{
   issueCount: 0,
   featureCount: 10,
   defectCount: 2,
+  internalCount: 1,
   backlogItemCount: 12
 }, {
   id: 55,
@@ -437,6 +491,7 @@ var dataProductsStats = [{
   issueCount: 0,
   featureCount: 11,
   defectCount: 0,
+  internalCount: 2,
   backlogItemCount: 11
 }, {
   id: 56,
@@ -445,6 +500,7 @@ var dataProductsStats = [{
   issueCount: 0,
   featureCount: 0,
   defectCount: 0,
+  internalCount: 3,
   backlogItemCount: 0
 }, {
   id: 57,
@@ -453,6 +509,7 @@ var dataProductsStats = [{
   issueCount: 0,
   featureCount: 17,
   defectCount: 1,
+  internalCount: 4,
   backlogItemCount: 18
 }];
 

--- a/tests/mock/service/mockRemoteProductsService.js
+++ b/tests/mock/service/mockRemoteProductsService.js
@@ -6,6 +6,7 @@ var dataRemoteProducts = {
     issueCount: 41,
     featureCount: 32,
     defectCount: 0,
+    internalCount: 0,
     backlogItemCount: 32
   }, {
     id: 3781,
@@ -14,6 +15,7 @@ var dataRemoteProducts = {
     issueCount: 0,
     featureCount: 5,
     defectCount: 0,
+    internalCount: 0,
     backlogItemCount: 5
   }, {
     id: 3783,
@@ -22,6 +24,7 @@ var dataRemoteProducts = {
     issueCount: 0,
     featureCount: 12,
     defectCount: 8,
+    internalCount: 0,
     backlogItemCount: 20
   }, {
     id: 3786,
@@ -30,6 +33,7 @@ var dataRemoteProducts = {
     issueCount: 0,
     featureCount: 42,
     defectCount: 0,
+    internalCount: 0,
     backlogItemCount: 42
   }, {
     id: 3789,
@@ -38,6 +42,7 @@ var dataRemoteProducts = {
     issueCount: 0,
     featureCount: 6,
     defectCount: 0,
+    internalCount: 0,
     backlogItemCount: 6
   }, {
     id: 3798,
@@ -46,6 +51,7 @@ var dataRemoteProducts = {
     issueCount: 0,
     featureCount: 43,
     defectCount: 0,
+    internalCount: 0,
     backlogItemCount: 43
   }, {
     id: 3816,
@@ -54,6 +60,7 @@ var dataRemoteProducts = {
     issueCount: 0,
     featureCount: 4,
     defectCount: 0,
+    internalCount: 0,
     backlogItemCount: 4
   }, {
     id: 3930,
@@ -62,6 +69,7 @@ var dataRemoteProducts = {
     issueCount: 0,
     featureCount: 10,
     defectCount: 0,
+    internalCount: 0,
     backlogItemCount: 10
   }, {
     id: 3968,
@@ -70,6 +78,7 @@ var dataRemoteProducts = {
     issueCount: 0,
     featureCount: 3,
     defectCount: 0,
+    internalCount: 0,
     backlogItemCount: 3
   }, {
     id: 4114,
@@ -78,6 +87,7 @@ var dataRemoteProducts = {
     issueCount: 0,
     featureCount: 0,
     defectCount: 0,
+    internalCount: 0,
     backlogItemCount: 0
   }, {
     id: 4182,
@@ -86,6 +96,7 @@ var dataRemoteProducts = {
     issueCount: 0,
     featureCount: 38,
     defectCount: 0,
+    internalCount: 0,
     backlogItemCount: 38
   }, {
     id: 4262,
@@ -94,6 +105,7 @@ var dataRemoteProducts = {
     issueCount: 0,
     featureCount: 10,
     defectCount: 0,
+    internalCount: 0,
     backlogItemCount: 10
   }, {
     id: 4391,
@@ -102,6 +114,7 @@ var dataRemoteProducts = {
     issueCount: 0,
     featureCount: 9,
     defectCount: 0,
+    internalCount: 0,
     backlogItemCount: 9
   }, {
     id: 4557,
@@ -110,6 +123,7 @@ var dataRemoteProducts = {
     issueCount: 1,
     featureCount: 5,
     defectCount: 0,
+    internalCount: 0,
     backlogItemCount: 5
   }, {
     id: 4731,
@@ -118,6 +132,7 @@ var dataRemoteProducts = {
     issueCount: 0,
     featureCount: 13,
     defectCount: 0,
+    internalCount: 0,
     backlogItemCount: 13
   }, {
     id: 4871,
@@ -126,6 +141,7 @@ var dataRemoteProducts = {
     issueCount: 4,
     featureCount: 25,
     defectCount: 6,
+    internalCount: 0,
     backlogItemCount: 31
   }, {
     id: 4889,
@@ -134,6 +150,7 @@ var dataRemoteProducts = {
     issueCount: 1,
     featureCount: 16,
     defectCount: 3,
+    internalCount: 0,
     backlogItemCount: 19
   }, {
     id: 4912,
@@ -142,6 +159,7 @@ var dataRemoteProducts = {
     issueCount: 0,
     featureCount: 18,
     defectCount: 0,
+    internalCount: 0,
     backlogItemCount: 18
   }, {
     id: 4965,
@@ -150,6 +168,7 @@ var dataRemoteProducts = {
     issueCount: 0,
     featureCount: 0,
     defectCount: 0,
+    internalCount: 0,
     backlogItemCount: 0
   }, {
     id: 5070,
@@ -158,6 +177,7 @@ var dataRemoteProducts = {
     issueCount: 9,
     featureCount: 24,
     defectCount: 1,
+    internalCount: 0,
     backlogItemCount: 25
   }, {
     id: 5270,
@@ -166,6 +186,7 @@ var dataRemoteProducts = {
     issueCount: 11,
     featureCount: 6,
     defectCount: 2,
+    internalCount: 0,
     backlogItemCount: 8
   }, {
     id: 5342,
@@ -174,6 +195,7 @@ var dataRemoteProducts = {
     issueCount: 2,
     featureCount: 8,
     defectCount: 0,
+    internalCount: 0,
     backlogItemCount: 8
   }, {
     id: 5523,
@@ -182,6 +204,7 @@ var dataRemoteProducts = {
     issueCount: 0,
     featureCount: 0,
     defectCount: 0,
+    internalCount: 0,
     backlogItemCount: 0
   }, {
     id: 5524,
@@ -190,6 +213,7 @@ var dataRemoteProducts = {
     issueCount: 0,
     featureCount: 0,
     defectCount: 0,
+    internalCount: 0,
     backlogItemCount: 0
   }, {
     id: 5525,
@@ -198,6 +222,7 @@ var dataRemoteProducts = {
     issueCount: 2,
     featureCount: 4,
     defectCount: 1,
+    internalCount: 0,
     backlogItemCount: 5
   }, {
     id: 5798,
@@ -206,6 +231,7 @@ var dataRemoteProducts = {
     issueCount: 0,
     featureCount: 2,
     defectCount: 1,
+    internalCount: 0,
     backlogItemCount: 3
   }, {
     id: 5870,
@@ -214,6 +240,7 @@ var dataRemoteProducts = {
     issueCount: 0,
     featureCount: 8,
     defectCount: 0,
+    internalCount: 0,
     backlogItemCount: 8
   }, {
     id: 5910,
@@ -222,6 +249,7 @@ var dataRemoteProducts = {
     issueCount: 0,
     featureCount: 8,
     defectCount: 0,
+    internalCount: 0,
     backlogItemCount: 8
   }, {
     id: 5962,
@@ -230,6 +258,7 @@ var dataRemoteProducts = {
     issueCount: 0,
     featureCount: 0,
     defectCount: 0,
+    internalCount: 0,
     backlogItemCount: 0
   }, {
     id: 6004,
@@ -238,6 +267,7 @@ var dataRemoteProducts = {
     issueCount: 1,
     featureCount: 24,
     defectCount: 0,
+    internalCount: 0,
     backlogItemCount: 24
   }, {
     id: 6029,
@@ -246,6 +276,7 @@ var dataRemoteProducts = {
     issueCount: 2,
     featureCount: 2,
     defectCount: 0,
+    internalCount: 0,
     backlogItemCount: 2
   }, {
     id: 6126,
@@ -254,6 +285,7 @@ var dataRemoteProducts = {
     issueCount: 0,
     featureCount: 9,
     defectCount: 0,
+    internalCount: 0,
     backlogItemCount: 9
   }, {
     id: 6157,
@@ -262,6 +294,7 @@ var dataRemoteProducts = {
     issueCount: 0,
     featureCount: 10,
     defectCount: 0,
+    internalCount: 0,
     backlogItemCount: 10
   }, {
     id: 6368,
@@ -270,6 +303,7 @@ var dataRemoteProducts = {
     issueCount: 0,
     featureCount: 18,
     defectCount: 5,
+    internalCount: 0,
     backlogItemCount: 23
   }, {
     id: 6369,
@@ -278,6 +312,7 @@ var dataRemoteProducts = {
     issueCount: 0,
     featureCount: 0,
     defectCount: 0,
+    internalCount: 0,
     backlogItemCount: 0
   }, {
     id: 6373,
@@ -286,6 +321,7 @@ var dataRemoteProducts = {
     issueCount: 0,
     featureCount: 0,
     defectCount: 0,
+    internalCount: 0,
     backlogItemCount: 0
   }, {
     id: 6486,
@@ -294,6 +330,7 @@ var dataRemoteProducts = {
     issueCount: 0,
     featureCount: 0,
     defectCount: 0,
+    internalCount: 0,
     backlogItemCount: 0
   }, {
     id: 6487,
@@ -302,6 +339,7 @@ var dataRemoteProducts = {
     issueCount: 0,
     featureCount: 5,
     defectCount: 1,
+    internalCount: 0,
     backlogItemCount: 6
   }, {
     id: 6620,
@@ -310,6 +348,7 @@ var dataRemoteProducts = {
     issueCount: 0,
     featureCount: 0,
     defectCount: 0,
+    internalCount: 0,
     backlogItemCount: 0
   }, {
     id: 6625,
@@ -318,6 +357,7 @@ var dataRemoteProducts = {
     issueCount: 0,
     featureCount: 3,
     defectCount: 0,
+    internalCount: 0,
     backlogItemCount: 3
   }, {
     id: 6626,
@@ -326,6 +366,7 @@ var dataRemoteProducts = {
     issueCount: 0,
     featureCount: 3,
     defectCount: 0,
+    internalCount: 0,
     backlogItemCount: 3
   }, {
     id: 6627,
@@ -334,6 +375,7 @@ var dataRemoteProducts = {
     issueCount: 0,
     featureCount: 1,
     defectCount: 0,
+    internalCount: 0,
     backlogItemCount: 1
   }, {
     id: 6629,
@@ -342,6 +384,7 @@ var dataRemoteProducts = {
     issueCount: 0,
     featureCount: 1,
     defectCount: 2,
+    internalCount: 0,
     backlogItemCount: 3
   }, {
     id: 6664,
@@ -350,6 +393,7 @@ var dataRemoteProducts = {
     issueCount: 0,
     featureCount: 4,
     defectCount: 0,
+    internalCount: 0,
     backlogItemCount: 4
   }, {
     id: 6828,
@@ -358,6 +402,7 @@ var dataRemoteProducts = {
     issueCount: 0,
     featureCount: 1,
     defectCount: 0,
+    internalCount: 0,
     backlogItemCount: 1
   }, {
     id: 7001,
@@ -366,6 +411,7 @@ var dataRemoteProducts = {
     issueCount: 0,
     featureCount: 5,
     defectCount: 5,
+    internalCount: 0,
     backlogItemCount: 10
   }, {
     id: 7036,
@@ -374,6 +420,7 @@ var dataRemoteProducts = {
     issueCount: 2,
     featureCount: 5,
     defectCount: 1,
+    internalCount: 0,
     backlogItemCount: 6
   }, {
     id: 7037,
@@ -382,6 +429,7 @@ var dataRemoteProducts = {
     issueCount: 0,
     featureCount: 4,
     defectCount: 1,
+    internalCount: 0,
     backlogItemCount: 5
   }, {
     id: 7400,
@@ -390,6 +438,7 @@ var dataRemoteProducts = {
     issueCount: 0,
     featureCount: 18,
     defectCount: 1,
+    internalCount: 0,
     backlogItemCount: 19
   }, {
     id: 7509,
@@ -398,6 +447,7 @@ var dataRemoteProducts = {
     issueCount: 0,
     featureCount: 34,
     defectCount: 4,
+    internalCount: 0,
     backlogItemCount: 38
   }, {
     id: 7516,
@@ -406,6 +456,7 @@ var dataRemoteProducts = {
     issueCount: 0,
     featureCount: 0,
     defectCount: 0,
+    internalCount: 0,
     backlogItemCount: 0
   }, {
     id: 7517,
@@ -414,6 +465,7 @@ var dataRemoteProducts = {
     issueCount: 0,
     featureCount: 19,
     defectCount: 2,
+    internalCount: 0,
     backlogItemCount: 21
   }, {
     id: 7529,
@@ -422,6 +474,7 @@ var dataRemoteProducts = {
     issueCount: 0,
     featureCount: 2,
     defectCount: 1,
+    internalCount: 1,
     backlogItemCount: 3
   }, {
     id: 7797,
@@ -430,6 +483,7 @@ var dataRemoteProducts = {
     issueCount: 0,
     featureCount: 10,
     defectCount: 2,
+    internalCount: 2,
     backlogItemCount: 12
   }, {
     id: 7869,
@@ -438,6 +492,7 @@ var dataRemoteProducts = {
     issueCount: 0,
     featureCount: 11,
     defectCount: 0,
+    internalCount: 3,
     backlogItemCount: 11
   }, {
     id: 7934,
@@ -446,6 +501,7 @@ var dataRemoteProducts = {
     issueCount: 0,
     featureCount: 0,
     defectCount: 0,
+    internalCount: 4,
     backlogItemCount: 0
   }, {
     id: 7948,
@@ -454,6 +510,7 @@ var dataRemoteProducts = {
     issueCount: 0,
     featureCount: 17,
     defectCount: 1,
+    internalCount: 0,
     backlogItemCount: 18
   }]
 };

--- a/tests/unit/controllers/internalRequestControllerTest.js
+++ b/tests/unit/controllers/internalRequestControllerTest.js
@@ -55,6 +55,7 @@ describe("controller: InternalRequestController", function () {
     module("mock.internalRequestRepo");
     module("mock.internalRequestsService");
     module("mock.remoteProductManagerRepo");
+    module("mock.product");
     module("mock.productsService");
     module("mock.user", function ($provide) {
       var User = function () {
@@ -163,8 +164,17 @@ describe("controller: InternalRequestController", function () {
 
       $scope.confirmDeleteInternalRequest(internalRequest);
 
-      expect($scope.openModal).toHaveBeenCalled();
+      expect($scope.openModal).toHaveBeenCalledWith("#deleteInternalRequestModal");
       expect($scope.internalRequestToDelete).toEqual(internalRequest);
+    });
+
+    it("addInternalRequest to open the modal", function () {
+      var internalRequest = new mockInternalRequest($q);
+
+      spyOn($scope, "openModal");
+
+      $scope.addInternalRequest();
+      expect($scope.openModal).toHaveBeenCalledWith("#addInternalRequestModal");
     });
 
     it("createInternalRequest create a new Internal Requst", function () {
@@ -209,13 +219,14 @@ describe("controller: InternalRequestController", function () {
       $scope.editInternalRequest(internalRequest);
 
       expect($scope.internalRequestToEdit).toEqual(internalRequest);
-      expect($scope.openModal).toHaveBeenCalled();
+      expect($scope.openModal).toHaveBeenCalledWith("#editInternalRequestModal");
     });
 
     it("pushFeatureRequest push a FeatureRequest", function () {
       var featureRequest = new mockFeatureRequest($q);
 
       $scope.featureRequestToPush = featureRequest;
+      $scope.featureRequestToPush.product = new mockProduct($q);
       $scope.products = [
         new mockProduct($q),
         new mockProduct($q)
@@ -243,44 +254,50 @@ describe("controller: InternalRequestController", function () {
 
       expect($scope.featureRequestToPush.title).toEqual(internalRequest.title);
       expect($scope.featureRequestToPush.description).toEqual(internalRequest.description);
-      expect($scope.featureRequestToPush.productId).toBe(null);
+      expect($scope.featureRequestToPush.product).toBe(null);
       expect($scope.featureRequestToPush.rpmId).toBe(null);
       expect($scope.featureRequestToPush.scopeId).toBe(null);
-      expect($scope.openModal).toHaveBeenCalled();
+      expect($scope.openModal).toHaveBeenCalledWith("#pushInternalRequestModal");
     });
 
     it("refreshRemoteProducts should call the service refresh for a given product id", function () {
       var featureRequest = new mockFeatureRequest($q);
+      featureRequest.product = new mockProduct($q);
+
       $scope.remoteProducts = {};
-      $scope.remoteProducts[featureRequest.productId] = {};
+      $scope.remoteProducts[featureRequest.product.id] = {};
       $scope.remoteProductsLoading = {};
-      $scope.remoteProductsLoading[featureRequest.productId] = false;
+      $scope.remoteProductsLoading[featureRequest.product.id] = false;
 
       spyOn(ProductsService, "refreshRemoteProducts");
 
-      $scope.refreshRemoteProducts(featureRequest.productId);
-      expect(ProductsService.refreshRemoteProducts).toHaveBeenCalledWith(featureRequest.productId);
+      $scope.refreshRemoteProducts(featureRequest.product.id);
+      expect(ProductsService.refreshRemoteProducts).toHaveBeenCalledWith(featureRequest.product.id);
     });
 
     it("refreshRemoteProducts should not call the service refresh for a given product id when remoteProductsLoading for that product id", function () {
       var featureRequest = new mockFeatureRequest($q);
+      featureRequest.product = new mockProduct($q);
+
       $scope.remoteProducts = {};
-      $scope.remoteProducts[featureRequest.productId] = {};
+      $scope.remoteProducts[featureRequest.product.id] = {};
       $scope.remoteProductsLoading = {};
-      $scope.remoteProductsLoading[featureRequest.productId] = true;
+      $scope.remoteProductsLoading[featureRequest.product.id] = true;
 
       spyOn(ProductsService, "refreshRemoteProducts");
 
-      $scope.refreshRemoteProducts(featureRequest.productId);
+      $scope.refreshRemoteProducts(featureRequest.product.id);
       expect(ProductsService.refreshRemoteProducts).not.toHaveBeenCalled();
     });
 
     it("refreshRemoteProducts should not call the service refresh when there is no given product id", function () {
       var featureRequest = new mockFeatureRequest($q);
+      featureRequest.product = new mockProduct($q);
+
       $scope.remoteProducts = {};
-      $scope.remoteProducts[featureRequest.productId] = {};
+      $scope.remoteProducts[featureRequest.product.id] = {};
       $scope.remoteProductsLoading = {};
-      $scope.remoteProductsLoading[featureRequest.productId] = false;
+      $scope.remoteProductsLoading[featureRequest.product.id] = false;
 
       spyOn(ProductsService, "refreshRemoteProducts");
 
@@ -337,6 +354,7 @@ describe("controller: InternalRequestController", function () {
 
     it("selectRemoteProducts select should call refresh for a given product id", function () {
       $scope.featureRequestToPush = new mockFeatureRequest($q);
+      $scope.featureRequestToPush.product = new mockProduct($q);
       $scope.remoteProducts = {};
 
       spyOn($scope, "refreshRemoteProducts");
@@ -347,8 +365,9 @@ describe("controller: InternalRequestController", function () {
 
     it("selectRemoteProducts select should not call refresh for a given product id if already loaded", function () {
       $scope.featureRequestToPush = new mockFeatureRequest($q);
+      $scope.featureRequestToPush.product = new mockProduct($q);
       $scope.remoteProducts = {};
-      $scope.remoteProducts[$scope.featureRequestToPush.productId] = {};
+      $scope.remoteProducts[$scope.featureRequestToPush.product.id] = $scope.featureRequestToPush.product;
 
       spyOn($scope, "refreshRemoteProducts");
 

--- a/tests/unit/services/internalRequestsServiceTest.js
+++ b/tests/unit/services/internalRequestsServiceTest.js
@@ -29,6 +29,7 @@ describe("service: InternalRequestsService", function () {
     module("app");
     module("mock.internalRequest");
     module("mock.internalRequestRepo");
+    module("mock.product");
     module("mock.wsApi");
 
     initializeVariables();
@@ -60,8 +61,9 @@ describe("service: InternalRequestsService", function () {
 
   describe("Do the service method", function () {
     it("pushFeatureRequest should push a FeatureRequest", function () {
-      var featureRequest = new mockFeatureRequest($q);
       var response;
+      var featureRequest = new mockFeatureRequest($q);
+      featureRequest.product = new mockProduct($q);
 
       service.pushFeatureRequest(featureRequest).then(function () {
         response = true;
@@ -75,9 +77,10 @@ describe("service: InternalRequestsService", function () {
     });
 
     it("pushFeatureRequest should not push an invalid FeatureRequest id", function () {
-      var featureRequest = new mockFeatureRequest($q);
       var response;
+      var featureRequest = new mockFeatureRequest($q);
       featureRequest.id = undefined;
+      featureRequest.product = new mockProduct($q);
 
       service.pushFeatureRequest(featureRequest).then(function () {
         response = true;
@@ -91,9 +94,9 @@ describe("service: InternalRequestsService", function () {
     });
 
     it("pushFeatureRequest should not push an invalid FeatureRequest productId", function () {
-      var featureRequest = new mockFeatureRequest($q);
       var response;
-      featureRequest.productId = undefined;
+      var featureRequest = new mockFeatureRequest($q);
+      featureRequest.product = undefined;
 
       service.pushFeatureRequest(featureRequest).then(function () {
         response = true;
@@ -107,8 +110,9 @@ describe("service: InternalRequestsService", function () {
     });
 
     it("pushFeatureRequest should not push an invalid FeatureRequest rpmId", function () {
-      var featureRequest = new mockFeatureRequest($q);
       var response;
+      var featureRequest = new mockFeatureRequest($q);
+      featureRequest.product = new mockProduct($q);
       featureRequest.rpmId = undefined;
 
       service.pushFeatureRequest(featureRequest).then(function () {
@@ -123,8 +127,9 @@ describe("service: InternalRequestsService", function () {
     });
 
     it("pushFeatureRequest should not push an invalid FeatureRequest scopeId", function () {
-      var featureRequest = new mockFeatureRequest($q);
       var response;
+      var featureRequest = new mockFeatureRequest($q);
+      featureRequest.product = new mockProduct($q);
       featureRequest.scopeId = undefined;
 
       service.pushFeatureRequest(featureRequest).then(function () {


### PR DESCRIPTION
Always associate the product received by remote products such as LSSS.
This requires redesigning the Service and UI to associate with a given product.
Whereas before, the product was only associated on push, the product is now associated on create/edit.

The "Add an Internal Request" buttons needs a function instead of directly calling open modal.
This function can then explicitly refresh the products listing so that the list is available.

Resolves #67