### PR TITLE
Issue 95: username/password for GitHub should be removed - no longer available

### DIFF
--- a/app/views/modals/editRemoteProjectManagerModal.html
+++ b/app/views/modals/editRemoteProjectManagerModal.html
@@ -14,7 +14,7 @@
 
     <validatedselect id="edit-type" options="serviceTypes" optionvalue="value" optionproperty="gloss" model="remoteProjectManagerToEdit" property="type" label="Type" form="remoteProjectManagerForms.edit" validations="remoteProjectManagerForms.validations" results="remoteProjectManagerForms.getResults()"></validatedselect>
 
-    <remote-project-manager-form ng-if="remoteProjectManagerToEdit.type" management-settings="typeSettings(remoteProjectManagerToEdit.type)" model="remoteProjectManagerToEdit"></remote-project-manager-form>
+    <remote-project-manager-form ng-if="remoteProjectManagerToEdit.type" management-type="remoteProjectManagerToEdit.type" management-settings="typeSettings(remoteProjectManagerToEdit.type)" model="remoteProjectManagerToEdit"></remote-project-manager-form>
   </div>
 
   <div class="modal-footer">

--- a/tests/unit/directives/remoteProjectManagerFormDirectiveTest.js
+++ b/tests/unit/directives/remoteProjectManagerFormDirectiveTest.js
@@ -1,37 +1,10 @@
 describe("directive: remoteProjectManagerForm", function () {
-  var $compile, $q, $scope, directive, element, formSettings, formModel;
+  var $compile, $q, $scope, directive, element;
 
   var initializeVariables = function () {
     inject(function (_$q_, _$compile_) {
       $q = _$q_;
       $compile = _$compile_;
-
-      formModel = {
-        name: "",
-        type: ""
-      };
-
-      formSettings = [{
-        type: "text",
-        key: "url",
-        gloss: "URL",
-        visible: true
-      }, {
-        type: "text",
-        key: "username",
-        gloss: "Username",
-        visible: false
-      }, {
-        type: "password",
-        key: "password",
-        gloss: "Password",
-        visible: false
-      }, {
-        type: "password",
-        key: "token",
-        gloss: "Token",
-        visible: false
-      }];
     });
   };
 
@@ -39,14 +12,47 @@ describe("directive: remoteProjectManagerForm", function () {
     inject(function (_$rootScope_) {
       $scope = _$rootScope_.$new();
 
-      var attr = settings && settings.attr ? settings.attr : "management-settings='settings' model='model'></remote-project-manager-form";
+      var attr = settings && settings.attr ? settings.attr : "management-settings='managementSettings' model='model'></remote-project-manager-form";
       var body = settings && settings.body ? settings.body : "";
+
+      var managementType = settings && settings.managementType ? settings.managementType : "type";
+
+      var managementSettings = settings && settings.managementSettings ? settings.managementSettings : [
+        {
+          type: "text",
+          key: "url",
+          gloss: "URL",
+          visible: true
+        },{
+          type: "text",
+          key: "username",
+          gloss: "Username",
+          visible: false
+        }, {
+          type: "password",
+          key: "password",
+          gloss: "Password",
+          visible: false
+        }, {
+          type: "password",
+          key: "token",
+          gloss: "Token",
+          visible: false
+        }
+      ];
+
+      var model = settings && settings.model ? settings.model : {
+        name: "",
+        type: "",
+        settings: {}
+      };
 
       element = angular.element("<remote-project-manager-form " + attr + ">" + body + "</remote-project-manager-form>");
       directive = $compile(element)($scope);
 
-      $scope.model = formModel;
-      $scope.settings = formSettings;
+      $scope.managementType = managementType;
+      $scope.managementSettings = managementSettings;
+      $scope.model = model;
 
       $scope.$digest();
     });
@@ -64,6 +70,36 @@ describe("directive: remoteProjectManagerForm", function () {
   describe("Is the directive", function () {
     it("defined", function () {
       initializeDirective();
+      expect(directive).toBeDefined();
+    });
+
+    it("defined with token auth", function () {
+      var settings = {
+        model: {
+          name: "",
+          type: "",
+          settings: {
+            token: "1234567890"
+          }
+        }
+      };
+
+      initializeDirective(settings);
+      expect(directive).toBeDefined();
+    });
+
+    it("defined with password auth", function () {
+      var settings = {
+        model: {
+          name: "",
+          type: "",
+          settings: {
+            password: "1234567890"
+          }
+        }
+      };
+
+      initializeDirective(settings);
       expect(directive).toBeDefined();
     });
   });


### PR DESCRIPTION
To actually achieve this, much of the directive is rewritten.

The management type string needs to be passed to the directive so that it can be determined whether or not the type has changed.
With the previous design, one could not reliably determine if/when the username/password fields should disappear or not.
The original management type is saved and then the auth information is updated if the management type changes.

It also turns out that if a watch is not used, then there is no reliable way to determine if the management type is the correct value.
Closing the modal and opening up a new model is a way to potentially get the wrong information as the data from the previous open model may be preserved.
I would argue that this is a pre-existing bug that needed to be fixed to ensure that the changes here work as expected.

The isAuthRequired() function is rewritten to better handle when the 'auth' checkbox should be presented or not.
This function then should only run when needed to avoid resetting auth data when the auth data should not be reset.

The originalType should be uninitialized so that the very first run can handle setting the auth.required.
In all other cases the auth.required should never be set when the management type changes.
This is, in part, because the auth data gets cleared and it could incorrectly set the auth.useToken value.

The hasToken() function has been replaced with refreshAuth() to achieve all of this.
The name is changed to better clarify the purpose and intent of the function.

This commit requires changes in the service.

resolves TAMULib/ProjectManagementService#95
relates TAMULib/ProjectManagementService#97