### PR TITLE
Issue 81: Fix "alt" text: "Cinque Terre"

### DIFF
--- a/app/views/home.html
+++ b/app/views/home.html
@@ -58,7 +58,7 @@
                         <span>{{card.number}}</span>
                         <span ng-repeat="assignee in card.assignees">
                           <span class="pull-right avatar" popover-trigger="'mouseenter'" uib-popover="{{assignee.name}}" popover-placement="auto top">
-                            <img src="{{getAvatarUrl(assignee)}}" class="img-circle" alt="Cinque Terre" width="20" height="20">
+                            <img src="{{getAvatarUrl(assignee)}}" class="img-circle" alt="{{assignee.name}}" width="20" height="20">
                           </span>
                         </span>
 


### PR DESCRIPTION
The "tooltip"/"title" turns out to be an issue where the account name from Github is not available.
A suggestion is to provide a fallback to the account name instead of the user name.
This would be a change in the service and not the UI.

relates TAMULib/ProjectManagementService#118
resolves #81 